### PR TITLE
Remove contributing section from README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,16 +69,6 @@ If your prompt requires a new tag:
       label: My New Tag
     ```
 
-## 🤝 Contributing
-
-Contributions, issues, and feature requests are welcome. Feel free to check the [issues page](https://github.com/your-username/thinkprompt/issues) if you want to contribute.
-
-1.  Fork the Project.
-2.  Create your Feature Branch (`git checkout -b feature/AmazingFeature`).
-3.  Commit your Changes (`git commit -m 'Add some AmazingFeature'`).
-4.  Push to the Branch (`git push origin feature/AmazingFeature`).
-5.  Open a Pull Request.
-
 ## 📄 License
 
 This project is licensed under the MIT License - see the `LICENSE.md` file for details. (Note: `LICENSE.md` to be added separately).


### PR DESCRIPTION
This commit removes the "Contributing" section from the README.md file as per your request. The section contained instructions on how to contribute to the project, which are no longer desired.